### PR TITLE
 Add `Static` keyword to functions defined in headers

### DIFF
--- a/include/Either.h
+++ b/include/Either.h
@@ -35,11 +35,15 @@
         a leftData;                     \
         b rightData;                    \
     } Either(a, b);                     \
+    static                              \
     Either(a, b) Left_##a##_##b(a v);   \
+    static                              \
     Either(a, b) Left_##a##_##b(a v) {  \
         return Left(a, b, v);           \
     }                                   \
+    static                              \
     Either(a, b) Right_##a##_##b(b v);  \
+    static                              \
     Either(a, b) Right_##a##_##b(b v) { \
         return Right(a, b, v);          \
     }

--- a/include/Maybe.h
+++ b/include/Maybe.h
@@ -34,11 +34,15 @@
         int just;                \
         t data;                  \
     } Maybe(t);                  \
+    static                       \
     Maybe(t) Just_##t(t val);    \
+    static                       \
     Maybe(t) Just_##t(t val) {   \
         return Just(t, val);     \
     }                            \
+    static                       \
     Maybe(t) Nothing_##t(void);  \
+    static                       \
     Maybe(t) Nothing_##t(void) { \
         return Nothing(t);       \
     }


### PR DESCRIPTION
Since the headers will be included in each translation unit, it seems prudent to declare the functions `static` and not have their names escape the translation unit.